### PR TITLE
Remove incorrect spaces

### DIFF
--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -70,12 +70,12 @@ changes since the publication of {{!RFC4180}}):
 
 1. Each record is located on a separate line, delimited by a line break (CRLF or LF). For example:
 
-   aaa,bbb,ccc CRLF<br/>
-   zzz,yyy,xxx CRLF
+   aaa,bbb,cccCRLF<br/>
+   zzz,yyy,xxxCRLF
 
 2. The last record in the file may or may not have an ending line break. For example:
 
-   aaa,bbb,ccc CRLF<br/>
+   aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxx
 
 3. There maybe an optional header line appearing as the first line
@@ -86,9 +86,9 @@ the rest of the file (the presence or absence of the header line
 should be indicated via the optional "header" parameter of this
 MIME type). For example:
 
-   field_name,field_name,field_name CRLF<br/>   
-   aaa,bbb,ccc CRLF<br/>
-   zzz,yyy,xxx CRLF
+   field_name,field_name,field_nameCRLF<br/>   
+   aaa,bbb,cccCRLF<br/>
+   zzz,yyy,xxxCRLF
 
 4. Within the header and each record, there may be one or more
 fields, separated by commas. Each line should contain the same


### PR DESCRIPTION
Fix [Errata 5714](https://www.rfc-editor.org/errata/eid5714)

> Errata ID: 5714
> Status: Verified
> Type: Editorial
> Publication Format(s) : TEXT
> Reported By: Damon Koach
> Date Reported: 2019-05-01
> Verifier Name: Barry Leiba
> Date Verified: 2019-05-01
> 
> Section 5, 6 says:
> 
> Section 5: 
>   "aaa","bbb","ccc" CRLF
> Section 6: 
>   "aaa","b CRLF
>   bb","ccc" CRLF
>   zzz,yyy,xxx
> 
> It should say:
> 
> Section 5:
>   "aaa","bbb","ccc"CRLF
> Section 6:
>   "aaa","b CRLF
>   bb","ccc"CRLF
>   zzz,yyy,xxx
> 
> Notes:
> 
> As implied in the ABNF grammar, escaped (quoted) fields may not be followed by a space.
> The corrected text removes those spaces from the examples, making them syntactically correct.