### PR TITLE
Newline after last record

### DIFF
--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -141,7 +141,7 @@ However, some implementations MAY use other values.
 The ABNF grammar (as per {{!RFC5234}}) appears as follows:
 
 ~~~~~~~~~~
-file = [header [CR]LF] 1*(record [CR]LF)
+file = [header [CR]LF] *(record [CR]LF)
 
 header = name *(COMMA name)
 

--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -73,10 +73,10 @@ changes since the publication of {{!RFC4180}}):
    aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxxCRLF
 
-2. The last record in the file may or may not have an ending line break. For example:
+2. The last record in the file must have an ending line break. For example:
 
    aaa,bbb,cccCRLF<br/>
-   zzz,yyy,xxx
+   zzz,yyy,xxxCRLF
 
 3. There maybe an optional header line appearing as the first line
 of the file with the same format as normal record lines. This
@@ -133,7 +133,7 @@ However, some implementations may use other values.
 The ABNF grammar (as per {{!RFC5234}}) appears as follows:
 
 ~~~~~~~~~~
-file = [header [CR]LF] record *([CR]LF record) [ [CR]LF ]
+file = [header [CR]LF] 1*(record [CR]LF)
 
 header = name *(COMMA name)
 

--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -73,7 +73,7 @@ changes since the publication of {{!RFC4180}}):
    aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxxCRLF
 
-2. The last record in the file must have an ending line break. For example:
+2. The last record in the file MUST have an ending line break. For example:
 
    aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxxCRLF


### PR DESCRIPTION
Fix [Errata 6230](https://www.rfc-editor.org/errata/eid6230).

> Errata ID: 6230
> Status: Reported
> Type: Technical
> Publication Format(s) : TEXT
> Reported By: Marco Diniz Sousa
> Date Reported: 2020-07-13
> 
> Section 2 says:
> 
> The last record in the file may or may not have an ending line break.
> 
> file = [header CRLF] record *(CRLF record) [CRLF]
> It should say:
> 
> The last record in the file must have an ending line break.
> 
> file = [header CRLF] record *(CRLF record) CRLF
> Notes:
> 
> The grammar seems to be ambiguous in the case below:
> - Records have just one field;
> - The last record may have an empty value.
> 
> File:
> header1CRLF
> aCRLF
> bCRLF
> EOF
> 
> In the file above, we do not know if we have four records (header1, a, b and an empty value) with the last record not ending with a line break; or if we have three records (header1, a and b) with the last record ending with a line break.
> 
> The grammar allows empty fields:
> non-escaped = *TEXTDATA
> 
> According to RFC 2234:
> "Default values are 0 and infinity so that *<element> allows any number, including zero;"