### PR TITLE
Proposal for unique header names

### DIFF
--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -89,7 +89,7 @@ changes since the publication of {{!RFC4180}}):
 of the file with the same format as normal record lines. This
 header will contain names corresponding to the fields in the file
 and SHOULD contain the same number of fields as the records in
-the rest of the file. Every name MUST be unique, if not empty.
+the rest of the file. Every name SHOULD be unique, if not empty.
 The presence or absence of the header line MAY be indicated via the
 optional "header" parameter of this MIME type. For example:
 

--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -89,11 +89,11 @@ changes since the publication of {{!RFC4180}}):
 of the file with the same format as normal record lines. This
 header will contain names corresponding to the fields in the file
 and SHOULD contain the same number of fields as the records in
-the rest of the file (the presence or absence of the header line
-MAY be indicated via the optional "header" parameter of this
-MIME type). For example:
+the rest of the file. Every name MUST be unique, if not empty.
+The presence or absence of the header line MAY be indicated via the
+optional "header" parameter of this MIME type. For example:
 
-   field_name,field_name,field_nameCRLF<br/>   
+   field_name_1,field_name_2,field_name_3CRLF<br/>
    aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxxCRLF
 

--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -89,7 +89,8 @@ changes since the publication of {{!RFC4180}}):
 of the file with the same format as normal record lines. This
 header will contain names corresponding to the fields in the file
 and SHOULD contain the same number of fields as the records in
-the rest of the file. Every name SHOULD be unique, if not empty.
+the rest of the file. Implementers should be aware that some
+applications may treat header values as unique.
 The presence or absence of the header line MAY be indicated via the
 optional "header" parameter of this MIME type. For example:
 


### PR DESCRIPTION
Multiple headers with the same name are problematic to handle when reading the file. What do you think of this additional SHOULD clause?