### PR TITLE
simplify header record definition

### DIFF
--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -146,8 +146,6 @@ file = *(record [CR]LF)
 
 record = field *(COMMA field)
 
-name = field
-
 field = (escaped / non-escaped)
 
 escaped = *(WSP) DQUOTE *(TEXTDATA / COMMA / CR / LF / 2DQUOTE) DQUOTE *(WSP)

--- a/draft-shafranovich-rfc4180-bis.md
+++ b/draft-shafranovich-rfc4180-bis.md
@@ -85,21 +85,21 @@ changes since the publication of {{!RFC4180}}):
    aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxxCRLF
 
-3. There MAY be an optional header line appearing as the first line
-of the file with the same format as normal record lines. This
+3. The first record in the file MAY be an optional header
+with the same format as normal records. This
 header will contain names corresponding to the fields in the file
 and SHOULD contain the same number of fields as the records in
 the rest of the file. Implementers should be aware that some
 applications may treat header values as unique.
-The presence or absence of the header line MAY be indicated via the
+The presence or absence of the header MAY be indicated via the
 optional "header" parameter of this MIME type. For example:
 
    field_name_1,field_name_2,field_name_3CRLF<br/>
    aaa,bbb,cccCRLF<br/>
    zzz,yyy,xxxCRLF
 
-4. Within the header and each record, there MAY be one or more
-fields, separated by commas. Each line SHOULD contain the same
+4. Within each record, there MAY be one or more
+fields, separated by commas. Each record SHOULD contain the same
 number of fields throughout the file. Spaces are considered part
 of a field and SHOULD NOT be ignored. The last field in the
 record MUST NOT be followed by a comma. For example:
@@ -142,9 +142,7 @@ However, some implementations MAY use other values.
 The ABNF grammar (as per {{!RFC5234}}) appears as follows:
 
 ~~~~~~~~~~
-file = [header [CR]LF] *(record [CR]LF)
-
-header = name *(COMMA name)
+file = *(record [CR]LF)
 
 record = field *(COMMA field)
 


### PR DESCRIPTION
As the header is using the same grammar as normal records, the ABNF can now (since #5) be further simplified. As a header might also span multiple lines (via enclosed fields) I also adjusted the wording from "line" to "record" in some places.